### PR TITLE
v0.1.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldiron/netherite",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",

--- a/src/core/classes/config.ts
+++ b/src/core/classes/config.ts
@@ -64,10 +64,30 @@ export class Config {
         return this.packName;
     }
     
+    /**
+     * @remarks The version of netherite that is currently installed globally on the system.
+     */
     public static get InstalledNetheriteVersion() : string {
         return deno.version;
     }
     
+    /**
+     * @remarks The version of netherite that is installed in the local project as a dependency.
+     */
+    public static get LocalNetheriteVersion() : string {
+        try {
+            const deno = JSON.parse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
+            const version: string = deno.imports["@coldiron/netherite"].split("^")[1];
+            return version;
+        } catch (_error) {
+            Logger.warn("No local version of netherite found, using global version instead.");
+            return this.InstalledNetheriteVersion;
+        }
+    }
+    
+    /**
+     * @remarks The latest version of netherite that is available on JSR.
+     */
     public static get LatestNetheriteVersion() : Promise<string> {
         return new Promise<string>((resolve, reject) => {
             if (this.meta) {
@@ -83,6 +103,9 @@ export class Config {
         });
     }
     
+    /**
+     * @remarks The beta version of netherite that is available on JSR.
+     */
     public static get BetaNetheriteVersion() : Promise<string> {
         function getBeta(meta: JSRMeta): string {
             const versions = Object.keys(meta.versions).filter((version) => version.includes("beta"));


### PR DESCRIPTION
## Changes
- Adjusted `build` and `export` commands to run through the local dependency version of Netherite for the given project, rather than the globally installed CLI version. This prevents potential issues where Developer A has version 1.0.0, Developer B has version 1.1.0, and the build output could be different between the two.