### PR TITLE
v0.2.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.2.2] - 7/11/2025
+### Changes
+- Fixed issue where `backticked` markdown strings where not included in the changelog when publishing Netherite packages.
+---
 ## [0.2.1] - 7/11/2025
 ### Changes
 - Added improved feedback to `netherite package publish`, which will now link to the actual pull request rather than the repo.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldiron/netherite",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",

--- a/src/core/classes/package.ts
+++ b/src/core/classes/package.ts
@@ -75,8 +75,8 @@ const action = "name: Publish\n" +
 	"\n" +
 	"      - name: Add changelog entry\n" +
 	"        run: |\n" +
-	"          echo \"## ${{ github.event.pull_request.title }}\" >> CHANGELOG.md\n" +
-	"          echo \"${{ github.event.pull_request.body }}\" >> CHANGELOG.md\n" +
+	"          echo '## ${{ github.event.pull_request.title }}' >> CHANGELOG.md\n" +
+	"          echo '${{ github.event.pull_request.body }}' >> CHANGELOG.md\n" +
 	"\n" +
 	"      - name: Commit and push changelog\n" +
 	"        run: |\n" +


### PR DESCRIPTION
### Changes
- Fixed issue where `backticked` markdown strings where not included in the changelog when publishing Netherite packages.