### PR TITLE
v0.2.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 # Changelog
+## [0.2.3] - 8/19/2025
+### Changes
+- Fixed issue where log messages generated while a spinner was active would be dropped instead of cached until the spinner completed.
+- General logging improvements
+- Fixed issue where JSON files with comments could break the build process.
+- Fixed issue where `netherite build --watch` could fail when the resources it attempts to copy are busy (i.e. when pasting folders into a project).
+---
 ## [0.2.2] - 7/11/2025
 ### Changes
 - Fixed issue where `backticked` markdown strings where not included in the changelog when publishing Netherite packages.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldiron/netherite",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",

--- a/src/core/classes/block.ts
+++ b/src/core/classes/block.ts
@@ -1,5 +1,5 @@
 import * as path from "@std/path";
-import { deepMerge, writeTextToDist } from "../utils/index.ts";
+import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { ClientBlocks} from "../../api/api.ts";
 
@@ -15,7 +15,7 @@ export class Block {
 
         for (const entry of Deno.readDirSync(dirPath)) {
             if (entry.name === "blocks.json") {
-                const fileContent: ClientBlocks = JSON.parse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
+                const fileContent: ClientBlocks = JSONCParse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
                 this.blocks = deepMerge(this.blocks, fileContent);
             }
         }
@@ -27,7 +27,7 @@ export class Block {
 
     public static watch(filePath: string): void {
         if (filePath.endsWith("blocks.json")) {
-            const fileContent: ClientBlocks = JSON.parse(Deno.readTextFileSync(filePath));
+            const fileContent: ClientBlocks = JSONCParse(Deno.readTextFileSync(filePath));
             this.blocks = deepMerge(this.blocks, fileContent);
         }
 

--- a/src/core/classes/block.ts
+++ b/src/core/classes/block.ts
@@ -2,6 +2,7 @@ import * as path from "@std/path";
 import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { ClientBlocks} from "../../api/api.ts";
+import { attemptRepeater } from "../utils/error.ts";
 
 export class Block {
     private static blocks: ClientBlocks = {};
@@ -26,11 +27,13 @@ export class Block {
     }
 
     public static watch(filePath: string): void {
-        if (filePath.endsWith("blocks.json")) {
-            const fileContent: ClientBlocks = JSONCParse(Deno.readTextFileSync(filePath));
-            this.blocks = deepMerge(this.blocks, fileContent);
-        }
+        attemptRepeater(() => {
+            if (filePath.endsWith("blocks.json")) {
+                const fileContent: ClientBlocks = JSONCParse(Deno.readTextFileSync(filePath));
+                this.blocks = deepMerge(this.blocks, fileContent);
+            }
 
-        this.build();
+            this.build();
+        });
     }
 }

--- a/src/core/classes/config.ts
+++ b/src/core/classes/config.ts
@@ -4,7 +4,7 @@ import { v4 } from "uuid";
 import * as path from "@std/path";
 import type { ProjectOptions } from "./project.ts";
 import { Buffer } from "node:buffer";
-import { Logger } from "../utils/index.ts";
+import { JSONCParse, Logger } from "../utils/index.ts";
 import { WorkerManager } from "./index.ts";
 import deno from "../../../deno.json" with {type: "json" };
 
@@ -76,7 +76,7 @@ export class Config {
      */
     public static get LocalNetheriteVersion() : string {
         try {
-            const deno = JSON.parse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
+            const deno = JSONCParse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
             const version: string = deno.imports["@coldiron/netherite"].split("^")[1];
             return version;
         } catch (_error) {

--- a/src/core/classes/language.ts
+++ b/src/core/classes/language.ts
@@ -3,6 +3,7 @@ import { formatText } from "../utils/text.ts";
 import { writeTextToDist } from "../utils/fileIO.ts";
 import { Config } from "./config.ts";
 import { sendToDist } from "../utils/index.ts";
+import { attemptRepeater } from "../utils/error.ts";
 
 export type LangType = "en_US" | "en_GB" | "de_DE" | "es_ES" | "es_MX" | "fr_FR" | "fr_CA" | "it_IT" | "ja_JP" | "ko_KR" | "pt_BR" | "pt_PT" | "ru_RU" | "zh_CN" | "zh_TW" | "nl_NL" | "bg_BG" | "cs_CZ" | "da_DK" | "el_GR" | "fi_FI" | "hu_HU" | "id_ID" | "nb_NO" | "pl_PL" | "sk_SK" | "sv_SE" | "tr_TR" | "uk_UA";
 
@@ -134,10 +135,12 @@ export class Language {
     }
     
     public static watch(filePath: string): void {
-        if (filePath.endsWith(".lang")) {
-            this.ingestFile(filePath);
-        }
+        attemptRepeater(() => {
+            if (filePath.endsWith(".lang")) {
+                this.ingestFile(filePath);
+            }
 
-        this.build();
+            this.build();
+        });
     }
 }

--- a/src/core/classes/manifest.ts
+++ b/src/core/classes/manifest.ts
@@ -2,6 +2,7 @@ import * as path from "@std/path";
 import type * as types from "../../api/types/index.d.ts";
 import { Config } from "./config.ts";
 import { writeTextToDist } from "../utils/fileIO.ts";
+import { JSONCParse } from "../utils/index.ts";
 
 export class Manifest {
     public static get BehaviorManifest() : Promise<types.Manifest> {
@@ -148,7 +149,7 @@ export class Manifest {
     private static getVersionNumber(module: string): string {
         if (Config.Options.scripting === "deno") {
             try {
-                const file = JSON.parse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
+                const file = JSONCParse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
                 const value = file.imports[module] as string|undefined;
         
                 if (!value) throw new Error(`Could not find module ${module} in deno.json`);
@@ -158,7 +159,7 @@ export class Manifest {
             }
         } else {
             try {
-                const file = JSON.parse(Deno.readTextFileSync(path.join(Deno.cwd(), "package.json")));
+                const file = JSONCParse(Deno.readTextFileSync(path.join(Deno.cwd(), "package.json")));
                 const value = file.dependencies[module] as string|undefined;
         
                 if (!value) throw new Error(`Could not find module ${module} in package.json`);

--- a/src/core/classes/package.ts
+++ b/src/core/classes/package.ts
@@ -1,6 +1,6 @@
 import * as path from "@std/path";
 import { Config } from "./config.ts";
-import { copyDirSync, Logger } from "../utils/index.ts";
+import { copyDirSync, JSONCParse, Logger } from "../utils/index.ts";
 
 interface NetheritePackage {
     /**
@@ -100,7 +100,7 @@ export class Package {
 
     public static get LatestVanillaVersion() : string {
         try {
-            const version = JSON.parse(Deno.readTextFileSync(path.join(Config.NetheriteDirectory, "bedrock-samples", "version.json")));
+            const version = JSONCParse(Deno.readTextFileSync(path.join(Config.NetheriteDirectory, "bedrock-samples", "version.json")));
             const latest = (version.latest.version as string).split(".");
             latest.length = 3;
             return latest.join(".");
@@ -225,7 +225,7 @@ export class Package {
         const packages: {dir: string, manifest: NetheriteManifest}[] = [];
 
         await this.iterateInstalledPackages((dir) => {
-            const manifest: NetheriteManifest = JSON.parse(Deno.readTextFileSync(path.join(dir, "netherite.manifest.json")));
+            const manifest: NetheriteManifest = JSONCParse(Deno.readTextFileSync(path.join(dir, "netherite.manifest.json")));
             packages.push({dir, manifest});
         });
 
@@ -237,7 +237,7 @@ export class Package {
         const packages: {dir: string, package: NetheritePackage}[] = [];
 
         await this.iterateLoadedPackages((dir) => {
-            const nPackage: NetheritePackage = JSON.parse(Deno.readTextFileSync(path.join(dir, "netherite.package.json")));
+            const nPackage: NetheritePackage = JSONCParse(Deno.readTextFileSync(path.join(dir, "netherite.package.json")));
             packages.push({dir, package: nPackage});
         });
 
@@ -268,7 +268,7 @@ export class Package {
         copyDirSync(path.join(nPackage.dir, "versions", useVersion), outPath);
 
         // Get imported package information
-        const packageInfo: NetheritePackage = JSON.parse(Deno.readTextFileSync(path.join(outPath, "netherite.package.json")));
+        const packageInfo: NetheritePackage = JSONCParse(Deno.readTextFileSync(path.join(outPath, "netherite.package.json")));
         if (!packageInfo) {
             Logger.Spinner.fail(`Failed to load ${nPackage.manifest.name} package, missing netherite.package.json`);
             Deno.exit(1);
@@ -276,7 +276,7 @@ export class Package {
 
         // If the package has an import, add it to the deno.json imports
         if (packageInfo.import) {
-            const deno = JSON.parse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
+            const deno = JSONCParse(Deno.readTextFileSync(path.join(Deno.cwd(), "deno.json")));
 
             if (!deno.imports) {
                 deno.imports = {};
@@ -320,7 +320,7 @@ export class Package {
         }
 
         await new Deno.Command("git", {args: ["pull"]}).output();
-        installedPackage.manifest = JSON.parse(Deno.readTextFileSync(path.join(installedPackage.dir, "netherite.manifest.json")));
+        installedPackage.manifest = JSONCParse(Deno.readTextFileSync(path.join(installedPackage.dir, "netherite.manifest.json")));
         let url = Deno.readTextFileSync(path.join(installedPackage.dir, ".git", "config"))
         .split("\n")
         .find(line => line.includes("url = "))?.split(" = ")[1].trim().replace(/\.git$/, "");

--- a/src/core/classes/skin.ts
+++ b/src/core/classes/skin.ts
@@ -1,5 +1,5 @@
 import * as path from "@std/path";
-import { deepMerge, writeTextToDist } from "../utils/index.ts";
+import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { Skins } from "../../api/api.ts";
 
@@ -15,7 +15,7 @@ export class Skin {
 
         for (const entry of Deno.readDirSync(dirPath)) {
             if (entry.name === "skins.json") {
-                const fileContent: Skins = JSON.parse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
+                const fileContent: Skins = JSONCParse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
                 this.skins = deepMerge(this.skins, fileContent);
             }
         }
@@ -27,7 +27,7 @@ export class Skin {
 
     public static watch(filePath: string): void {
         if (filePath.endsWith("skins.json")) {
-            const fileContent: Skins = JSON.parse(Deno.readTextFileSync(filePath));
+            const fileContent: Skins = JSONCParse(Deno.readTextFileSync(filePath));
             this.skins = deepMerge(this.skins, fileContent);
         }
 

--- a/src/core/classes/skin.ts
+++ b/src/core/classes/skin.ts
@@ -2,6 +2,7 @@ import * as path from "@std/path";
 import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { Skins } from "../../api/api.ts";
+import { attemptRepeater } from "../utils/error.ts";
 
 export class Skin {
     private static skins: Partial<Skins> = {};
@@ -26,11 +27,13 @@ export class Skin {
     }
 
     public static watch(filePath: string): void {
-        if (filePath.endsWith("skins.json")) {
-            const fileContent: Skins = JSONCParse(Deno.readTextFileSync(filePath));
-            this.skins = deepMerge(this.skins, fileContent);
-        }
+        attemptRepeater(() => {
+            if (filePath.endsWith("skins.json")) {
+                const fileContent: Skins = JSONCParse(Deno.readTextFileSync(filePath));
+                this.skins = deepMerge(this.skins, fileContent);
+            }
 
-        this.build();
+            this.build();
+        });
     }
 }

--- a/src/core/classes/sound.ts
+++ b/src/core/classes/sound.ts
@@ -2,6 +2,7 @@ import * as path from "@std/path";
 import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { ClientSoundDefinitions, ClientSounds } from "../../api/api.ts";
+import { attemptRepeater } from "../utils/error.ts";
 
 export class Sound {
     private static soundDefinitions: ClientSoundDefinitions = {
@@ -38,14 +39,16 @@ export class Sound {
     }
 
     public static watch(filePath: string): void {
-        if (filePath.endsWith("sound_definitions.json")) {
-            const fileContent: ClientSoundDefinitions = JSONCParse(Deno.readTextFileSync(filePath));
-            this.soundDefinitions = deepMerge(this.soundDefinitions, fileContent);
-        } else if (filePath.endsWith("sounds.json")) {
-            const fileContent: ClientSounds = JSONCParse(Deno.readTextFileSync(filePath));
-            this.sounds = deepMerge(this.sounds, fileContent);
-        }
+        attemptRepeater(() => {
+            if (filePath.endsWith("sound_definitions.json")) {
+                const fileContent: ClientSoundDefinitions = JSONCParse(Deno.readTextFileSync(filePath));
+                this.soundDefinitions = deepMerge(this.soundDefinitions, fileContent);
+            } else if (filePath.endsWith("sounds.json")) {
+                const fileContent: ClientSounds = JSONCParse(Deno.readTextFileSync(filePath));
+                this.sounds = deepMerge(this.sounds, fileContent);
+            }
 
-        this.build();
+            this.build();
+        });
     }
 }

--- a/src/core/classes/sound.ts
+++ b/src/core/classes/sound.ts
@@ -1,5 +1,5 @@
 import * as path from "@std/path";
-import { deepMerge, writeTextToDist } from "../utils/index.ts";
+import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { ClientSoundDefinitions, ClientSounds } from "../../api/api.ts";
 
@@ -20,10 +20,10 @@ export class Sound {
 
         for (const entry of Deno.readDirSync(dirPath)) {
             if (entry.name === "sound_definitions.json") {
-                const fileContent: ClientSoundDefinitions = JSON.parse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
+                const fileContent: ClientSoundDefinitions = JSONCParse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
                 this.soundDefinitions = deepMerge(this.soundDefinitions, fileContent);
             } else if (entry.name === "sounds.json") {
-                const fileContent: ClientSounds = JSON.parse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
+                const fileContent: ClientSounds = JSONCParse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
                 this.sounds = deepMerge(this.sounds, fileContent);
             }
         }
@@ -39,10 +39,10 @@ export class Sound {
 
     public static watch(filePath: string): void {
         if (filePath.endsWith("sound_definitions.json")) {
-            const fileContent: ClientSoundDefinitions = JSON.parse(Deno.readTextFileSync(filePath));
+            const fileContent: ClientSoundDefinitions = JSONCParse(Deno.readTextFileSync(filePath));
             this.soundDefinitions = deepMerge(this.soundDefinitions, fileContent);
         } else if (filePath.endsWith("sounds.json")) {
-            const fileContent: ClientSounds = JSON.parse(Deno.readTextFileSync(filePath));
+            const fileContent: ClientSounds = JSONCParse(Deno.readTextFileSync(filePath));
             this.sounds = deepMerge(this.sounds, fileContent);
         }
 

--- a/src/core/classes/texture.ts
+++ b/src/core/classes/texture.ts
@@ -1,5 +1,5 @@
 import * as path from "@std/path";
-import { deepMerge, writeTextToDist } from "../utils/index.ts";
+import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { ClientItemTexture, ClientTerrainTexture } from "../../api/api.ts";
 
@@ -27,10 +27,10 @@ export class Texture {
 
         for (const entry of Deno.readDirSync(dirPath)) {
             if (entry.name === "terrain_texture.json") {
-                const fileContent: ClientTerrainTexture = JSON.parse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
+                const fileContent: ClientTerrainTexture = JSONCParse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
                 this.terrainTexture = deepMerge(this.terrainTexture, fileContent);
             } else if (entry.name === "item_texture.json") {
-                const fileContent: ClientItemTexture = JSON.parse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
+                const fileContent: ClientItemTexture = JSONCParse(Deno.readTextFileSync(path.join(dirPath, entry.name)));
                 this.itemTexture = deepMerge(this.itemTexture, fileContent);
             }
         }
@@ -46,10 +46,10 @@ export class Texture {
 
     public static watch(filePath: string): void {
         if (filePath.endsWith("terrain_texture.json")) {
-            const fileContent: ClientTerrainTexture = JSON.parse(Deno.readTextFileSync(filePath));
+            const fileContent: ClientTerrainTexture = JSONCParse(Deno.readTextFileSync(filePath));
             this.terrainTexture = deepMerge(this.terrainTexture, fileContent);
         } else if (filePath.endsWith("item_texture.json")) {
-            const fileContent: ClientItemTexture = JSON.parse(Deno.readTextFileSync(filePath));
+            const fileContent: ClientItemTexture = JSONCParse(Deno.readTextFileSync(filePath));
             this.itemTexture = deepMerge(this.itemTexture, fileContent);
         }
 

--- a/src/core/classes/texture.ts
+++ b/src/core/classes/texture.ts
@@ -2,6 +2,7 @@ import * as path from "@std/path";
 import { deepMerge, JSONCParse, writeTextToDist } from "../utils/index.ts";
 import { Config } from "./index.ts";
 import type { ClientItemTexture, ClientTerrainTexture } from "../../api/api.ts";
+import { attemptRepeater } from "../utils/error.ts";
 
 export class Texture {
     private static terrainTexture: ClientTerrainTexture = {
@@ -45,14 +46,16 @@ export class Texture {
     }
 
     public static watch(filePath: string): void {
-        if (filePath.endsWith("terrain_texture.json")) {
-            const fileContent: ClientTerrainTexture = JSONCParse(Deno.readTextFileSync(filePath));
-            this.terrainTexture = deepMerge(this.terrainTexture, fileContent);
-        } else if (filePath.endsWith("item_texture.json")) {
-            const fileContent: ClientItemTexture = JSONCParse(Deno.readTextFileSync(filePath));
-            this.itemTexture = deepMerge(this.itemTexture, fileContent);
-        }
+        attemptRepeater(() => {
+            if (filePath.endsWith("terrain_texture.json")) {
+                const fileContent: ClientTerrainTexture = JSONCParse(Deno.readTextFileSync(filePath));
+                this.terrainTexture = deepMerge(this.terrainTexture, fileContent);
+            } else if (filePath.endsWith("item_texture.json")) {
+                const fileContent: ClientItemTexture = JSONCParse(Deno.readTextFileSync(filePath));
+                this.itemTexture = deepMerge(this.itemTexture, fileContent);
+            }
 
-        this.build();
+            this.build();
+        });
     }
 }

--- a/src/core/utils/error.ts
+++ b/src/core/utils/error.ts
@@ -1,0 +1,18 @@
+import { Logger, sleep } from "./index.ts";
+
+export async function attemptRepeater(func: () => unknown, attempts: number = 5): Promise<void> {
+    let lastError: string = "";
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+        try {
+            func();
+            return;
+        } catch (error) {
+            lastError = (error instanceof Error) ? error.message : String(error);
+            Logger.warn(`Failed ${attempt}/${attempts} times due to: ${lastError}`, true);
+            await sleep(1000);
+        }
+    }
+
+    Logger.error(`Failed due to: ${lastError}`);
+}

--- a/src/core/utils/error.ts
+++ b/src/core/utils/error.ts
@@ -3,7 +3,7 @@ import { Logger, sleep } from "./index.ts";
 export async function attemptRepeater(func: () => unknown, attempts: number = 5): Promise<void> {
     let lastError: string = "";
 
-    for (let attempt = 0; attempt < attempts; attempt++) {
+    for (let attempt = 1; attempt <= attempts; attempt++) {
         try {
             func();
             return;

--- a/src/core/utils/logger.ts
+++ b/src/core/utils/logger.ts
@@ -17,7 +17,7 @@ class Spinner extends Kia {
 export class Logger {
     private static spinner: Spinner;
     private static isSpinning: boolean = false;
-    private static spinnerResolve: (result: "success"| "failure") => void;
+    private static cachedMessages: string[] = [];
     
     public static Verbose: boolean = false;
 
@@ -32,13 +32,13 @@ export class Logger {
         },
         succeed: function(text: string) {
             Logger.spinner.succeed(text);
-            Logger.spinnerResolve?.("success");
             Logger.isSpinning = false;
+            Logger.logCachedMessages();
         },
         fail: function(text: string) {
             Logger.spinner.fail(text);
-            Logger.spinnerResolve?.("failure");
             Logger.isSpinning = false;
+            Logger.logCachedMessages();
         },
     });
 
@@ -47,45 +47,54 @@ export class Logger {
     public static log(message: string, verbose?: boolean) {
         if (!Logger.Verbose && verbose) return;
 
+        const formattedMessage = `[${this.getCurrentTime()}] ${Colors.green("INFO")} ${message}`;
+
         if (Logger.isSpinning) {
-            this.spinnerResult().then(() => console.log(message));
+            this.cachedMessages.push(formattedMessage);
         } else {
-            console.log(message);
+            console.log(formattedMessage);
         }
     }
 
     public static warn(message: string, verbose?: boolean) {
         if (!Logger.Verbose && verbose) return;
 
+        const formattedMessage = `[${this.getCurrentTime()}] ${Colors.yellow("WARN")} ${message}`;
+
         if (Logger.isSpinning) {
-            this.spinnerResult().then(() => console.log(this.Colors.yellow(message)));
+            this.cachedMessages.push(formattedMessage);
         } else {
-            console.log(this.Colors.yellow(message));
+            console.log(formattedMessage);
         }
     }
 
     public static error(message: string, verbose?: boolean) {
         if (!Logger.Verbose && verbose) return;
 
+        const formattedMessage = `[${this.getCurrentTime()}] ${Colors.red("ERROR")} ${message}`;
+
         if (Logger.isSpinning) {
-            this.spinnerResult().then(() => console.log(this.Colors.red(message)));
+            this.cachedMessages.push(formattedMessage);
         } else {
-            console.log(this.Colors.red(message));
+            console.log(formattedMessage);
         }
     }
 
-    private static spinnerResult(): Promise<"success" | "failure" | "inactive"> {
-        return new Promise((resolve) => {
-            if (!Logger.spinner?.isSpinning()) {
-                resolve("inactive");
-                return;
-            }
+    private static logCachedMessages(): void {
+        for (const msg of this.cachedMessages) {
+            console.log(msg);
+        }
 
-            Logger.spinnerResolve = resolve;
-        });
+        this.cachedMessages.length = 0;
     }
 
     private static clearLine(): void {
         Deno.stdout.writeSync(new TextEncoder().encode("\x1b[" + "2K\r"));
+    }
+
+    private static getCurrentTime(): string {
+        const now = new Date();
+        const pad = (n: number) => n.toString().padStart(2, "0");
+        return `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
     }
 }

--- a/src/core/utils/text.ts
+++ b/src/core/utils/text.ts
@@ -17,12 +17,15 @@ export function capitalize(text: string): string {
 }
 
 export function keywordReplacer(content: string, options: ProjectOptions): string {
+    const path = options.namespace.replace(/_/, "/");
+
     const modifiedContent = content
     .replace(/FORMATVERSION/g, options.format_version)
     .replace(/NAMESPACE/g, options.namespace)
     .replace(/VERSION/g, options.version)
     .replace(/AUTHOR/g, options.author)
     .replace(/NAME/g, options.name)
+    .replace(/PATH/g, path)
 
     return modifiedContent;
 }


### PR DESCRIPTION
### Changes
- Fixed issue where log messages generated while a spinner was active would be dropped instead of cached until the spinner completed.
- General logging improvements
- Fixed issue where JSON files with comments could break the build process.
- Fixed issue where `netherite build --watch` could fail when the resources it attempts to copy are busy (i.e. when pasting folders into a project).