### PR TITLE
fixes/misc

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",
     "init": "cd .. && rm -rf Test && netherite init --name 'Test' --author 'Caleb Coldiron' --namespace 'cld_test' --format_version 'latest' --type 'world' --skinpack --no-publish",
-    "install": "deno install -f -g -c deno.json --name netherite --allow-import --allow-read --allow-write --allow-run --allow-env --allow-net=localhost:3000,jsr.io src/cli/cli.ts",
+    "install": "deno install -f -g -c deno.json --name netherite --allow-import --allow-read --allow-write --allow-run --allow-env --allow-net=localhost:0,jsr.io src/cli/cli.ts",
     "test": "deno task install && deno task init"
   },
   "license": "MIT",

--- a/deno.json
+++ b/deno.json
@@ -4,9 +4,9 @@
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",
-    "init": "cd .. && netherite init --name 'Test' --author 'Caleb Coldiron' --namespace 'cld_test' --format_version 'latest' --type 'world' --skinpack --no-publish",
+    "init": "cd .. && rm -rf Test && netherite init --name 'Test' --author 'Caleb Coldiron' --namespace 'cld_test' --format_version 'latest' --type 'world' --skinpack --no-publish",
     "install": "deno install -f -g -c deno.json --name netherite --allow-import --allow-read --allow-write --allow-run --allow-env --allow-net=localhost:3000,jsr.io src/cli/cli.ts",
-    "test": "rm -rf ../Test && deno task install && deno task init"
+    "test": "deno task install && deno task init"
   },
   "license": "MIT",
   "exports": {

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -72,7 +72,13 @@ export class Command<T extends CommandData> {
         const version = Config.InstalledNetheriteVersion;
 
         try {
-            if (version.includes("beta")) {
+            if (Deno.args.includes("--local")) {
+                const compareVersion = await Config.LatestNetheriteVersion;
+                if (compareVersion !== version) {
+                    Logger.log(Logger.Colors.yellow(`Your project is using ${version}, but version ${Logger.Colors.green(compareVersion)} is available. Upgrade to latest with ${Logger.Colors.cyan(`deno add jsr:@coldiron/netherite`)}`));
+                    return;
+                }
+            } else if (version.includes("beta")) {
                 const compareVersion = await Config.BetaNetheriteVersion;
                 if (compareVersion !== version) {
                     Logger.log(Logger.Colors.yellow(`You are using version ${version}, but version ${Logger.Colors.green(compareVersion)} is available. Upgrade to latest beta with ${Logger.Colors.cyan(`deno run -A jsr:@coldiron/netherite/install beta`)}`));

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -3,7 +3,6 @@ import { Command, type CommandData } from "../command.ts";
 import { Project } from "../../core/classes/project.ts";
 import { abortOnKeypress, Logger } from "../../core/utils/index.ts";
 import { Config } from "../../core/classes/config.ts";
-import { run } from "node:test";
 
 interface BuildCommandData extends CommandData {
     options: {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -16,7 +16,7 @@ if (arg === "beta") {
             "--allow-write",
             "--allow-run",
             "--allow-env",
-            "--allow-net=localhost:3000,jsr.io",
+            "--allow-net=localhost:0,jsr.io",
             `jsr:@coldiron/netherite@${beta}/cli`
         ],
         stdout: "inherit",
@@ -36,7 +36,7 @@ if (arg === "beta") {
             "--allow-write",
             "--allow-run",
             "--allow-env",
-            "--allow-net=localhost:3000,jsr.io",
+            "--allow-net=localhost:0,jsr.io",
             `jsr:@coldiron/netherite@${latest}/cli`
         ],
         stdout: "inherit",

--- a/src/core/classes/config.ts
+++ b/src/core/classes/config.ts
@@ -174,8 +174,7 @@ export class Config {
         const namespaceParts = this.Options.namespace.split("_");
 
         if (namespaceParts.length !== 2) {
-            Logger.error("Namespace must be in the format of 'author_name'");
-            Deno.exit(1);
+            throw new Error("Namespace must be in the format of 'author_name'");
         }
 
         this.studioName = namespaceParts[0];

--- a/src/core/classes/sound.ts
+++ b/src/core/classes/sound.ts
@@ -6,7 +6,7 @@ import { attemptRepeater } from "../utils/error.ts";
 
 export class Sound {
     private static soundDefinitions: ClientSoundDefinitions = {
-        format_version: "1.0.0",
+        format_version: "FORMATVERSION",
         sound_definitions: {}
     };
 
@@ -31,11 +31,13 @@ export class Sound {
     }
     
     public static build(): void {
-        if (Object.keys(this.soundDefinitions.sound_definitions).length)
-            writeTextToDist(path.join(Config.Paths.rp.root, "sounds.json"), JSON.stringify(this.soundDefinitions, null, "\t"));
+        if (Object.keys(this.sounds).length) {
+            writeTextToDist(path.join(Config.Paths.rp.root, "sounds.json"), JSON.stringify(this.sounds, null, "\t"));
+        }
 
-        if (Object.keys(this.sounds).length)
+        if (Object.keys(this.soundDefinitions).length) {
             writeTextToDist(path.join(Config.Paths.rp.root, "sounds", "sound_definitions.json"), JSON.stringify(this.soundDefinitions, null, "\t"));
+        }
     }
 
     public static watch(filePath: string): void {

--- a/src/core/classes/static.ts
+++ b/src/core/classes/static.ts
@@ -23,7 +23,7 @@ export class Static {
         ["**/*.lang", Language.watch.bind(Language)],
         ["**/scripts/**/*.ts", Script.watch.bind(Script)],
         ["**/textures/*.json", Texture.watch.bind(Texture)],
-        ["**/sound/sound_definitions.json", Sound.watch.bind(Sound)],
+        ["**/sounds/sound_definitions.json", Sound.watch.bind(Sound)],
     ]);
 
     public static build(watch?: boolean) {

--- a/src/core/classes/static.ts
+++ b/src/core/classes/static.ts
@@ -136,7 +136,7 @@ export class Static {
 
             try {
                 const stat = Deno.statSync(src);
-                if (stat.isDirectory) return;
+                if (stat.isDirectory && event.kind !== "rename") return;
             } catch (_error) {
                 // Do Nothing
             }
@@ -168,8 +168,12 @@ export class Static {
                     break;
                 }
                 case "remove": {
-                    Deno.removeSync(dest, {recursive: true});
-                    Logger.log(`[${Logger.Colors.red("remove")}] ${dest}`);
+                    try {
+                        Deno.removeSync(dest, { recursive: true });
+                        Logger.log(`[${Logger.Colors.red("remove")}] ${dest}`);
+                    } catch (_error) {
+                        // File was already removed at dest.
+                    }
                     break;
                 }
                 default:

--- a/src/core/classes/texture.ts
+++ b/src/core/classes/texture.ts
@@ -59,11 +59,13 @@ export class Texture {
     }
     
     public static buildSource(): void {
-        if (Object.keys(this.terrainTexture.texture_data).length) 
+        if (Object.keys(this.terrainTexture.texture_data).length) {
             writeTextToSrc("./src/resource_pack/textures/terrain_texture.json", JSON.stringify(this.terrainTexture, null, "\t"));
+        }
 
-        if (Object.keys(this.itemTexture.texture_data).length)
+        if (Object.keys(this.itemTexture.texture_data).length) {
             writeTextToSrc("./src/resource_pack/textures/item_texture.json", JSON.stringify(this.itemTexture, null, "\t"));
+        }
     }
 
     public static watch(filePath: string): void {


### PR DESCRIPTION
- Closes #41, fixed issue where moving/renaming/deleting a directory could cause the watcher to crash.
- Closes #40, fixed issue where `sound_definition.json` contents were incorrectly writing to `sounds.json`.
- Closes #39, the message printed to users now distinguishes between local (project) and global (installed) versions and gives the appropriate update suggestion accordingly.
- Closes #32, fixed issue where the program would exit before properly disposing of the spinner, causing the error message to be lost.