### PR TITLE
hotfix/0.3.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.3.3] - 9/25/2025
+### Changes
+- Fixed issue where `.mcfunction` files did not perform text replacement for keywords like `NAMESPACE`.
+---
 ## [0.3.2] - 9/11/2025
 ### Changes
 - Fixed issue where `new attachable` command improperly handled the `--stack` argument, causing it to default to 64 and incorrectly be written as a string if provided.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldiron/netherite",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",

--- a/src/core/utils/fileIO.ts
+++ b/src/core/utils/fileIO.ts
@@ -107,7 +107,7 @@ export function writeTextToSrc(dest: string, content: string, overwrite: boolean
 }
 
 export function isTextFile(filename: string): boolean {
-    const textFileExtensions = [".ts", ".js", ".json", ".txt", ".md", ".lang"];
+    const textFileExtensions = [".ts", ".js", ".json", ".txt", ".md", ".lang", ".mcfunction"];
     return textFileExtensions.some(ext => filename.endsWith(ext));
 }
 


### PR DESCRIPTION
\### Changes

\- Fixed issue where `.mcfunction` files did not perform text replacement for keywords like `NAMESPACE`.

