### PR TITLE
hotfix/0.3.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.3.4] - 10/2/2025
+### Changes
+- Fixed issue where temporary files created by external programs (like image editors) could crash the build watch process.
+- Fixed issue where the `animate` property in `MinecraftClientEntity` only accepted strings instead of allowing for key value pairs.
+- Fixed issue where the auto-generated manifest's dependency section could fail to properly parse the installed dependency's version. Also added support for detecting the `-beta` flag.
+---
 ## [0.3.3] - 9/25/2025
 ### Changes
 - Fixed issue where `.mcfunction` files did not perform text replacement for keywords like `NAMESPACE`.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldiron/netherite",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
     "encode": "deno run -A src/templates/encode.ts",

--- a/src/api/types/client_entity.ts
+++ b/src/api/types/client_entity.ts
@@ -26,7 +26,7 @@ interface ClientEntityScripts {
     variables?: {
         [key: string]: "public";
     };
-    animate?: string[];
+    animate?: (string|{ [key: string]: Molang })[];
     initialize?: string[];
     parent_setup?: string;
     pre_animation?: string[];

--- a/src/core/classes/build/manifest.ts
+++ b/src/core/classes/build/manifest.ts
@@ -152,7 +152,9 @@ export class Manifest {
             const value = file.imports[module] as string | undefined;
 
             if (!value) throw new Error(`Could not find module ${module} in deno.json`);
-            return value.split("@^")[1]; // TODO: handle beta versions correctly
+            const match = value.match(/\d+\.\d+\.\d+(-beta)?/)?.[0];
+            if (!match) throw new Error(`Failed to parse ${module} version in deno.json`);
+            return match; // TODO: handle beta versions correctly
         } catch (_error) {
             throw new Error(`Could not get version number for module ${module} as deno.json doesn't exist`);
         }


### PR DESCRIPTION
### Changes
- Fixed issue where temporary files created by external programs (like image editors) could crash the build watch process.
- Fixed issue where the `animate` property in `MinecraftClientEntity` only accepted strings instead of allowing for key value pairs.
- Fixed issue where the auto-generated manifest's dependency section could fail to properly parse the installed dependency's version. Also added support for detecting the `-beta` flag.