### PR TITLE
fixes/misc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,4 +13,9 @@ jobs:
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
       - uses: actions/checkout@v6
-      - run: npx jsr publish
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Publish to JSR
+        run: deno publish

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## [1.0.1] - 07/13/2026
+- Fixed issue where the validator for Server and Client entities was overly opinionated.
 ## [1.0.0] - 06/10/2026
 - Updated `package create` and `package publish` to work around git tags instead of versioned folders.
 - Added `package update` command

--- a/deno.json
+++ b/deno.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "tasks": {
     "dev": "deno run --allow-read --allow-write --allow-run --allow-env src/cli/cli.ts",
+    "check": "deno check src/core/core.ts && deno check src/cli/cli.ts && deno check src/api/api.ts && deno check src/cli/install.ts",
     "encode": "deno run -A src/templates/encode.ts",
     "init": "cd .. && rm -rf Test && netherite init --name 'Test' --author 'Caleb Coldiron' --namespace 'cld_test' --format_version 'latest' --type 'world' --skinpack --vibrant_visuals --no-publish",
     "install": "deno install -f -g -c deno.json --name netherite --allow-import --allow-read --allow-write --allow-run --allow-env --allow-net=localhost,jsr.io,raw.githubusercontent.com src/cli/cli.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1,6 +1,7 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@cross/image@~0.4.3": "0.4.3",
     "jsr:@deno-library/compress@~0.5.5": "0.5.5",
     "jsr:@deno-library/crc32@1.0.2": "1.0.2",
     "jsr:@jonasschiano/kia@^0.0.120": "0.0.120",
@@ -9,7 +10,7 @@
     "jsr:@std/assert@1": "1.0.10",
     "jsr:@std/async@*": "1.0.10",
     "jsr:@std/async@^1.0.11": "1.0.11",
-    "jsr:@std/bytes@^1.0.2": "1.0.4",
+    "jsr:@std/bytes@^1.0.2": "1.0.5",
     "jsr:@std/bytes@^1.0.5": "1.0.5",
     "jsr:@std/cli@^1.0.14": "1.0.14",
     "jsr:@std/collections@*": "1.0.10",
@@ -42,6 +43,9 @@
     "npm:uuid@^11.1.0": "11.1.0"
   },
   "jsr": {
+    "@cross/image@0.4.3": {
+      "integrity": "35de7afd2b3ea800dad368ff364e735f66b2719dbd053084fa42b0d233e3492c"
+    },
     "@deno-library/compress@0.5.5": {
       "integrity": "18b651a33eac87d96ae8c941487045724a665d654e9d94120da43777393655d9",
       "dependencies": [

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,3 +1,7 @@
+/**
+ * This module contains the type and class information for Netherite's API when working in `*.mod.ts` files.
+ * @module
+ */
 export * from "./config.ts";
 export * from "./types/index.ts";
 export * from "./classes/index.ts";

--- a/src/api/classes/client_animation.ts
+++ b/src/api/classes/client_animation.ts
@@ -2,7 +2,15 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientAnimationLoose, ClientAnimationStrict } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Animation `*.anim.json`.
+ */
 export class MinecraftClientAnimation extends MinecraftWriteable<ClientAnimationLoose, ClientAnimationStrict> {
+    /**
+     * Creates an animation entry for a given item using the skeletal attachable pattern.
+     * @param name The unique item name.
+     * @returns The Animation instance.
+     */
     public static skeletalAttachable(name: string): MinecraftClientAnimation {
         return new MinecraftClientAnimation({
             format_version: "1.10.0",

--- a/src/api/classes/client_animation.ts
+++ b/src/api/classes/client_animation.ts
@@ -11,7 +11,7 @@ export class MinecraftClientAnimation extends MinecraftWriteable<ClientAnimation
      * @param name The unique item name.
      * @returns The Animation instance.
      */
-    public static skeletalAttachable(name: string): MinecraftClientAnimation {
+    public static skeletalAttachable(name: string, subpath?: string): MinecraftClientAnimation {
         return new MinecraftClientAnimation({
             format_version: "1.10.0",
             animations: {
@@ -25,7 +25,7 @@ export class MinecraftClientAnimation extends MinecraftWriteable<ClientAnimation
                 [`animation.$NAMESPACE.item.${name}.attack.first_person`]: { loop: "hold_on_last_frame", animation_length: 0.5, bones: { [name]: { "rotation": { "0.0": [-40, 60, -40], "0.1": { "pre": [-33, 56, -60], "post": [-33, 56, -60], "lerp_mode": "catmullrom" }, "0.2": [-39, 57, -81], "0.3": [-90, 40, -100], "0.4": [-40, 60, -40], "0.5": [-40, 60, -40] }, "position": { "0.0": [-3, 0, 0], "0.1": { "pre": [-3, 4, -8], "post": [-3, 4, -8], "lerp_mode": "catmullrom" }, "0.2": [19, -8, -10], "0.3": [23, -10, -15], "0.4": [17, -10, -11], "0.5": [-3, 0, 0] } } }, timeline: { 0.0: "v.playing_custom_attack = 1;", 0.5: "v.playing_custom_attack = 0;" } },
                 [`animation.$NAMESPACE.item.${name}.attack.third_person`]: {},
             }
-        }, name);
+        }, name, subpath);
     }
     
     public get Animation() : ClientAnimationLoose {
@@ -36,8 +36,9 @@ export class MinecraftClientAnimation extends MinecraftWriteable<ClientAnimation
         return this.name;
     }
 
-    constructor(obj: ClientAnimationLoose, protected readonly name: string) {
+    constructor(obj: ClientAnimationLoose, protected readonly name: string, protected readonly subpath: string = "") {
         super(obj);
+        this.subpath &&= this.subpath + "/";
     }
     
     protected validate(): ClientAnimationStrict {
@@ -46,7 +47,7 @@ export class MinecraftClientAnimation extends MinecraftWriteable<ClientAnimation
 
     protected generate(): WriteableResponse<ModuleResponse> {
         return {
-            endpoint: `RP/animations/${this.name}.anim.json`,
+            endpoint: `RP/animations/${this.subpath}${this.name}.anim.json`,
             response: {
                 name: name,
                 data: this.encode(),

--- a/src/api/classes/client_animation_controller.ts
+++ b/src/api/classes/client_animation_controller.ts
@@ -11,7 +11,7 @@ export class MinecraftClientAnimationController extends MinecraftWriteable<Clien
      * @param name The unique item name.
      * @returns The AnimationController instance.
      */
-    public static skeletalAttachable(name: string): MinecraftClientAnimationController {
+    public static skeletalAttachable(name: string, subpath?: string): MinecraftClientAnimationController {
         return new MinecraftClientAnimationController({
             format_version: "1.10.0",
             animation_controllers: {
@@ -72,7 +72,7 @@ export class MinecraftClientAnimationController extends MinecraftWriteable<Clien
                     }
                 }
             }
-        }, name);
+        }, name, subpath);
     }
     
     public get AnimationController() : ClientAnimationControllerLoose {
@@ -83,8 +83,9 @@ export class MinecraftClientAnimationController extends MinecraftWriteable<Clien
         return this.name;
     }
 
-    constructor(obj: ClientAnimationControllerLoose, protected readonly name: string) {
+    constructor(obj: ClientAnimationControllerLoose, protected readonly name: string, protected readonly subpath: string = "") {
         super(obj);
+        this.subpath &&= this.subpath + "/";
     }
     
     protected validate(): ClientAnimationControllerStrict {
@@ -93,7 +94,7 @@ export class MinecraftClientAnimationController extends MinecraftWriteable<Clien
 
     protected generate(): WriteableResponse<ModuleResponse> {
         return {
-            endpoint: `RP/animation_controllers/${this.name}.ac.json`,
+            endpoint: `RP/animation_controllers/${this.subpath}${this.name}.ac.json`,
             response: {
                 name: name,
                 data: this.encode(),

--- a/src/api/classes/client_animation_controller.ts
+++ b/src/api/classes/client_animation_controller.ts
@@ -2,7 +2,15 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientAnimationControllerLoose, ClientAnimationControllerStrict } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Animation Controllers `*.ac.json`.
+ */
 export class MinecraftClientAnimationController extends MinecraftWriteable<ClientAnimationControllerLoose, ClientAnimationControllerStrict> {
+    /**
+     * Creates a new animation controller using the skeletal attachable pattern.
+     * @param name The unique item name.
+     * @returns The AnimationController instance.
+     */
     public static skeletalAttachable(name: string): MinecraftClientAnimationController {
         return new MinecraftClientAnimationController({
             format_version: "1.10.0",

--- a/src/api/classes/client_attachable.ts
+++ b/src/api/classes/client_attachable.ts
@@ -12,7 +12,7 @@ export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachab
      * @param piece The piece type (i.e. helmet, chestplate, etc).
      * @returns The Attachable instance.
      */
-    public static armor(name: string, piece: string): MinecraftClientAttachable {
+    public static armor(name: string, piece: string, subpath?: string): MinecraftClientAttachable {
         const setName = name.replace(`_${piece}`, "");
 
         return new MinecraftClientAttachable({
@@ -46,7 +46,7 @@ export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachab
                     ]
                 }
             }
-        });
+        }, subpath);
     }
 
     /**
@@ -101,6 +101,11 @@ export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachab
     public get Identifier() : string {
         return this.minecraftObj["minecraft:attachable"].description.identifier ?? "$NAMESPACE:SHORTNAME";
     }
+
+    constructor(obj: ClientAttachableLoose, protected readonly subpath: string = "") {
+        super(obj);
+        this.subpath &&= this.subpath + "/";
+    }
     
     protected validate(): ClientAttachableStrict {
         if (!this.minecraftObj["minecraft:attachable"]?.description?.identifier) {
@@ -131,7 +136,7 @@ export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachab
         const data = this.encode();
 
         return {
-            endpoint: `RP/attachables/${this.Shortname}.json`,
+            endpoint: `RP/attachables/${this.subpath}${this.Shortname}.json`,
             response: {
                 name: this.Shortname,
                 data,

--- a/src/api/classes/client_attachable.ts
+++ b/src/api/classes/client_attachable.ts
@@ -2,7 +2,16 @@ import { type WriteableResponse, type ModuleResponse, deepMerge } from "../../co
 import type { ClientAttachableStrict, ClientAttachableLoose } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Attachables.
+ */
 export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachableLoose, ClientAttachableStrict> {
+    /**
+     * Creates a new attachable as a piece of armor.
+     * @param name The unique item name.
+     * @param piece The piece type (i.e. helmet, chestplate, etc).
+     * @returns The Attachable instance.
+     */
     public static armor(name: string, piece: string): MinecraftClientAttachable {
         const setName = name.replace(`_${piece}`, "");
 
@@ -40,6 +49,11 @@ export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachab
         });
     }
 
+    /**
+     * Creates an attachable for a given item using the skeletal attachable pattern.
+     * @param name The unique item name.
+     * @returns The Attachable instance.
+     */
     public static skeletal(name: string): MinecraftClientAttachable {
         return new MinecraftClientAttachable({
             format_version: "1.10.0",
@@ -102,15 +116,9 @@ export class MinecraftClientAttachable extends MinecraftWriteable<ClientAttachab
             "minecraft:attachable": {
                 description: {
                     identifier: "",
-                    materials: {
-                        default: "entity_alphatest"
-                    },
-                    geometry: {
-                        default: "geometry.empty"
-                    },
-                    textures: {
-                        default: "textures/empty"
-                    },
+                    materials: {},
+                    geometry: {},
+                    textures: {},
                     render_controllers: []
                 },
             }

--- a/src/api/classes/client_blocks.ts
+++ b/src/api/classes/client_blocks.ts
@@ -2,6 +2,9 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientBlocks } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Blocks.
+ */
 export class MinecraftClientBlocks extends MinecraftWriteable<ClientBlocks, ClientBlocks> {
     public get Blocks() : ClientBlocks {
         return this.minecraftObj;

--- a/src/api/classes/client_entity.ts
+++ b/src/api/classes/client_entity.ts
@@ -11,9 +11,8 @@ export class MinecraftClientEntity extends MinecraftWriteable<ClientEntityLoose,
      * @param name The entity name.
      * @returns The Entity instance.
      */
-    public static dummy(name: string): MinecraftClientEntity {
-        return new MinecraftClientEntity(
-            {
+    public static dummy(name: string, subpath?: string): MinecraftClientEntity {
+        return new MinecraftClientEntity({
                 format_version: "$FORMATVERSION",
                 "minecraft:client_entity": {
                     description: {
@@ -32,8 +31,7 @@ export class MinecraftClientEntity extends MinecraftWriteable<ClientEntityLoose,
                         ],
                     }
                 }
-            }
-        );
+            }, subpath);
     }
     
     public get Entity() : ClientEntityLoose {
@@ -42,6 +40,11 @@ export class MinecraftClientEntity extends MinecraftWriteable<ClientEntityLoose,
     
     public get Identifier() : string {
         return this.minecraftObj["minecraft:client_entity"].description.identifier ?? "$NAMESPACE:SHORTNAME";
+    }
+
+    constructor(obj: ClientEntityLoose, protected readonly subpath: string = "") {
+        super(obj);
+        this.subpath &&= this.subpath + "/";
     }
 
     /**
@@ -81,7 +84,7 @@ export class MinecraftClientEntity extends MinecraftWriteable<ClientEntityLoose,
 
     protected generate(): WriteableResponse<ModuleResponse> {
         return {
-            endpoint: `RP/entity/${this.Shortname}.entity.json`,
+            endpoint: `RP/entity/${this.subpath}${this.Shortname}.entity.json`,
             response: {
                 name: this.Shortname,
                 data: this.encode(),

--- a/src/api/classes/client_entity.ts
+++ b/src/api/classes/client_entity.ts
@@ -2,7 +2,15 @@ import { type WriteableResponse, type ModuleResponse, deepMerge } from "../../co
 import type { ClientEntityStrict, ClientEntityLoose, Molang } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Entities `*.entity.json`.
+ */
 export class MinecraftClientEntity extends MinecraftWriteable<ClientEntityLoose, ClientEntityStrict> {
+    /**
+     * Creates a new entity with default options.
+     * @param name The entity name.
+     * @returns The Entity instance.
+     */
     public static dummy(name: string): MinecraftClientEntity {
         return new MinecraftClientEntity(
             {

--- a/src/api/classes/client_geometry.ts
+++ b/src/api/classes/client_geometry.ts
@@ -2,7 +2,16 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientGeometryLoose, ClientGeometryStrict } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Geometries `*.geo.json`.
+ */
 export class MinecraftClientGeometry extends MinecraftWriteable<ClientGeometryLoose, ClientGeometryStrict> {
+    /**
+     * Creates a Geometry as a standard cube shape.
+     * @param name The geo shortname.
+     * @param subpath The subpath (i.e. `entities` for `geos/entities/<name>`).
+     * @returns The Geometry instance.
+     */
     public static cube(name: string, subpath: string): MinecraftClientGeometry {
         return new MinecraftClientGeometry({
             format_version: "1.12.0",
@@ -34,6 +43,11 @@ export class MinecraftClientGeometry extends MinecraftWriteable<ClientGeometryLo
         }, name, subpath);
     }
 
+    /**
+     * Creates a set of armor from a template.
+     * @param name The unique item name.
+     * @returns The Geometry instance.
+     */
     public static armor(name: string): MinecraftClientGeometry {
         return new MinecraftClientGeometry({
             format_version: "1.8.0",
@@ -277,6 +291,11 @@ export class MinecraftClientGeometry extends MinecraftWriteable<ClientGeometryLo
         }, name, "entity/player");
     }
 
+    /**
+     * Creates a geometry for a given item using the skeletal attachable pattern.
+     * @param name The unique item name.
+     * @returns The Attachable instance.
+     */
     public static skeletalAttachable(name: string): MinecraftClientGeometry {
         return new MinecraftClientGeometry({
             format_version: "1.12.0",
@@ -397,6 +416,12 @@ export class MinecraftClientGeometry extends MinecraftWriteable<ClientGeometryLo
         return this.name;
     }
 
+    /**
+     * Creates a new `MinecraftClientGeometry`.
+     * @param obj The source Geometry object.
+     * @param name The geometry shortname.
+     * @param subpath The subpath (i.e. `entities` for `geos/entities/<name>`).
+     */
     constructor(obj: ClientGeometryLoose, protected readonly name: string, protected readonly subpath: string) {
         super(obj);
     }

--- a/src/api/classes/client_item_texture.ts
+++ b/src/api/classes/client_item_texture.ts
@@ -2,6 +2,9 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientItemTexture } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Item Textures.
+ */
 export class MinecraftClientItemTexture extends MinecraftWriteable<Partial<ClientItemTexture>, ClientItemTexture> {
     public get ItemTexture() : Partial<ClientItemTexture> {
         return this.minecraftObj;

--- a/src/api/classes/client_language.ts
+++ b/src/api/classes/client_language.ts
@@ -2,6 +2,9 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientLanguage, LangType } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Language files.
+ */
 export class MinecraftClientLanguage extends MinecraftWriteable<ClientLanguage, ClientLanguage> {
     /**
      * Adds a new entry to the lang file.

--- a/src/api/classes/client_render_controller.ts
+++ b/src/api/classes/client_render_controller.ts
@@ -2,7 +2,15 @@ import { type WriteableResponse, type ModuleResponse, deepMerge } from "../../co
 import type { ClientRenderControllerStrict, ClientRenderControllerLoose } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Render Controllers.
+ */
 export class MinecraftClientRenderController extends MinecraftWriteable<ClientRenderControllerLoose, ClientRenderControllerStrict> {
+    /**
+     * Creates a default render controller.
+     * @param name The entity name.
+     * @returns The RenderController instance.
+     */
     public static default(name: string): MinecraftClientRenderController {
         return new MinecraftClientRenderController({
                 format_version: "1.10.0",

--- a/src/api/classes/client_render_controller.ts
+++ b/src/api/classes/client_render_controller.ts
@@ -11,7 +11,7 @@ export class MinecraftClientRenderController extends MinecraftWriteable<ClientRe
      * @param name The entity name.
      * @returns The RenderController instance.
      */
-    public static default(name: string): MinecraftClientRenderController {
+    public static default(name: string, subpath?: string): MinecraftClientRenderController {
         return new MinecraftClientRenderController({
                 format_version: "1.10.0",
                 render_controllers: {
@@ -25,7 +25,7 @@ export class MinecraftClientRenderController extends MinecraftWriteable<ClientRe
                         ]
                     }
                 }
-            }, name);
+            }, name, subpath);
     }
     
     public get RenderController() : ClientRenderControllerLoose {
@@ -36,8 +36,9 @@ export class MinecraftClientRenderController extends MinecraftWriteable<ClientRe
         return `$NAMESPACE:${this.name}`;
     }
 
-    constructor(obj: ClientRenderControllerLoose, protected readonly name: string) {
+    constructor(obj: ClientRenderControllerLoose, protected readonly name: string, protected readonly subpath: string = "") {
         super(obj);
+        this.subpath &&= this.subpath + "/";
     }
     
     protected validate(): ClientRenderControllerStrict {
@@ -51,7 +52,7 @@ export class MinecraftClientRenderController extends MinecraftWriteable<ClientRe
 
     protected generate(): WriteableResponse<ModuleResponse> {
         return {
-            endpoint: `RP/render_controllers/${this.Shortname}.rc.json`,
+            endpoint: `RP/render_controllers/${this.subpath}${this.Shortname}.rc.json`,
             response: {
                 name: this.Shortname,
                 data: this.encode(),

--- a/src/api/classes/client_terrain_texture.ts
+++ b/src/api/classes/client_terrain_texture.ts
@@ -2,6 +2,9 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ClientTerrainTexture } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Client Terrain Textures.
+ */
 export class MinecraftClientTerrainTexture extends MinecraftWriteable<Partial<ClientTerrainTexture>, ClientTerrainTexture> {
     public get TerrainTexture() : Partial<ClientTerrainTexture> {
         return this.minecraftObj;

--- a/src/api/classes/index.ts
+++ b/src/api/classes/index.ts
@@ -1,4 +1,3 @@
-export * from "./minecraft_writeable.ts";
 export * from "./server_item.ts";
 export * from "./server_entity.ts";
 export * from "./server_block.ts";

--- a/src/api/classes/minecraft_writeable.ts
+++ b/src/api/classes/minecraft_writeable.ts
@@ -1,5 +1,8 @@
 import { type WriteableResponse, type ModuleWriteable, ModuleWriter, deepMerge, type ModuleResponse } from "../../core/core.ts";
 
+/**
+ * The base class for working with writeable files using Netherite's `*.mod.ts` pattern. Should not be used directly.
+ */
 export abstract class MinecraftWriteable<Loose extends object, Strict extends Loose> {
     protected minecraftObj: Loose;
     protected warnings?: string[];

--- a/src/api/classes/server_block.ts
+++ b/src/api/classes/server_block.ts
@@ -4,8 +4,16 @@ import type { BlockGeometry, BlockMaterialInstances } from "../types/server_bloc
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 import { MinecraftServerItem } from "./server_item.ts";
 
+/**
+ * A class for creating and working with Server Blocks.
+ */
 export class MinecraftServerBlock extends MinecraftWriteable<ServerBlockLoose, ServerBlockStrict> {
     // #region Static
+    /**
+     * Creates a template block.
+     * @param identifier The block identifier.
+     * @returns The Block instance.
+     */
     public static dummy(identifier: string): MinecraftServerBlock {
         if (!identifier.includes(":")) identifier = "$NAMESPACE:" + identifier;
 

--- a/src/api/classes/server_block.ts
+++ b/src/api/classes/server_block.ts
@@ -14,7 +14,7 @@ export class MinecraftServerBlock extends MinecraftWriteable<ServerBlockLoose, S
      * @param identifier The block identifier.
      * @returns The Block instance.
      */
-    public static dummy(identifier: string): MinecraftServerBlock {
+    public static dummy(identifier: string, subpath?: string): MinecraftServerBlock {
         if (!identifier.includes(":")) identifier = "$NAMESPACE:" + identifier;
 
         return new MinecraftServerBlock({
@@ -29,7 +29,7 @@ export class MinecraftServerBlock extends MinecraftWriteable<ServerBlockLoose, S
                     "minecraft:display_name": `tile.${identifier}.name`,
                 }
             }
-        });
+        }, subpath);
     }
 
     // #endregion
@@ -41,6 +41,11 @@ export class MinecraftServerBlock extends MinecraftWriteable<ServerBlockLoose, S
     
     public get Identifier() : string {
         return this.minecraftObj["minecraft:block"]?.description?.identifier ?? "$NAMESPACE:SHORTNAME";
+    }
+
+    constructor(obj: ServerBlockLoose, protected readonly subpath: string = "") {
+        super(obj);
+        this.subpath &&= this.subpath + "/";
     }
 
     /**
@@ -119,7 +124,7 @@ export class MinecraftServerBlock extends MinecraftWriteable<ServerBlockLoose, S
 
     protected generate(): WriteableResponse<ModuleResponse> {
         const response = {
-            endpoint: `BP/blocks/${this.Shortname}.json`,
+            endpoint: `BP/blocks/${this.subpath}${this.Shortname}.json`,
             response: {
                 name: `${this.Shortname}`,
                 data: this.encode(),

--- a/src/api/classes/server_entity.ts
+++ b/src/api/classes/server_entity.ts
@@ -3,8 +3,16 @@ import { Float } from "../types/float.ts";
 import type { ServerEntityStrict, ServerEntityLoose } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Server Entities.
+ */
 export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose, ServerEntityStrict> {
     // #region Static
+    /**
+     * Generates a dummy entity with no physics, collision, damage handling, or targeting.
+     * @param identifier The entity identifier.
+     * @returns The Entity instance.
+     */
     public static dummy(identifier: string): MinecraftServerEntity {
         return new MinecraftServerEntity({
             "minecraft:entity": {
@@ -21,7 +29,7 @@ export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose,
                 components: {
                     "minecraft:type_family": {
                         family: [
-                            identifier,
+                            "$NAMESPACE:" + identifier,
                         ]
                     },
                     "minecraft:collision_box": {
@@ -32,6 +40,7 @@ export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose,
                         has_collision: false,
                         has_gravity: false,
                     },
+                    "minecraft:cannot_be_attacked": {},
                     "minecraft:damage_sensor": {
                         triggers: [
                             {

--- a/src/api/classes/server_entity.ts
+++ b/src/api/classes/server_entity.ts
@@ -13,7 +13,7 @@ export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose,
      * @param identifier The entity identifier.
      * @returns The Entity instance.
      */
-    public static dummy(identifier: string): MinecraftServerEntity {
+    public static dummy(identifier: string, subpath?: string): MinecraftServerEntity {
         return new MinecraftServerEntity({
             "minecraft:entity": {
                 description: {
@@ -64,7 +64,7 @@ export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose,
                     }
                 }
             }
-        });
+        }, subpath);
     }
 
     // #endregion
@@ -75,6 +75,11 @@ export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose,
     
     public get Identifier() : string {
         return this.minecraftObj["minecraft:entity"].description?.identifier ?? "$NAMESPACE:SHORTNAME";
+    }
+
+    constructor(obj: ServerEntityLoose, protected readonly subpath: string = "") {
+        super(obj);
+        this.subpath &&= this.subpath + "/";
     }
 
     protected override validate(): ServerEntityStrict {
@@ -128,7 +133,7 @@ export class MinecraftServerEntity extends MinecraftWriteable<ServerEntityLoose,
 
     protected generate(): WriteableResponse<ModuleResponse> {
         const response = {
-            endpoint: `BP/entities/${this.Shortname}.json`,
+            endpoint: `BP/entities/${this.subpath}${this.Shortname}.json`,
             response: {
                 name: `${this.Shortname}`,
                 data: this.encode(),

--- a/src/api/classes/server_item.ts
+++ b/src/api/classes/server_item.ts
@@ -1,10 +1,19 @@
-import { Language, type WriteableResponse, type ModuleResponse, deepMerge } from "../../core/core.ts";
+import { type WriteableResponse, type ModuleResponse, deepMerge } from "../../core/core.ts";
 import type { ServerItemStrict, ServerItemLoose, ServerItemCooldown } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Server Items.
+ */
 export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, ServerItemStrict> {
     // #region Static
-
+    /**
+     * Creates a template item file.
+     * @param identifier The item identifier.
+     * @param stack_size An optional max stack size.
+     * @param cooldown An optional cooldown duration.
+     * @returns The Item instance.
+     */
     public static dummy(identifier: string, stack_size?: number, cooldown?: number): MinecraftServerItem {
         const cooldownComp: ServerItemCooldown|undefined = cooldown !== undefined ? {category: "SHORTNAME", duration: cooldown} : undefined;
 
@@ -28,6 +37,13 @@ export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, Ser
         });
     }
 
+    /**
+     * Creates a new item file using the skeletal attachable pattern.
+     * @param identifier The item identifier.
+     * @param stack_size An optional max stack size.
+     * @param cooldown An optional cooldown duration.
+     * @returns The Item instance.
+     */
     public static attachable(identifier: string, stack_size?: number, cooldown?: number): MinecraftServerItem {
         const cooldownComp: ServerItemCooldown|undefined = cooldown !== undefined ? {category: "SHORTNAME", duration: cooldown} : undefined;
 
@@ -55,6 +71,13 @@ export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, Ser
         });
     }
 
+    /**
+     * Creates a weareable armor-type item.
+     * @param identifier The item identifier.
+     * @param slot The weapon slot, (i.e. helmet, chestplate, leggings, boots).
+     * @param protection The protection level for the armor.
+     * @returns The Item instance.
+     */
     public static armor(identifier: string, slot: string, protection?: number): MinecraftServerItem {
         return new MinecraftServerItem({
             "minecraft:item": {

--- a/src/api/classes/server_item.ts
+++ b/src/api/classes/server_item.ts
@@ -12,9 +12,10 @@ export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, Ser
      * @param identifier The item identifier.
      * @param stack_size An optional max stack size.
      * @param cooldown An optional cooldown duration.
+     * @param subpath An optional subpath the file should be output to.
      * @returns The Item instance.
      */
-    public static dummy(identifier: string, stack_size?: number, cooldown?: number): MinecraftServerItem {
+    public static dummy(identifier: string, stack_size?: number, cooldown?: number, subpath?: string): MinecraftServerItem {
         const cooldownComp: ServerItemCooldown|undefined = cooldown !== undefined ? {category: "SHORTNAME", duration: cooldown} : undefined;
 
         return new MinecraftServerItem({
@@ -34,7 +35,7 @@ export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, Ser
                     "minecraft:cooldown": cooldownComp,
                 },
             }
-        });
+        }, subpath);
     }
 
     /**
@@ -112,6 +113,11 @@ export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, Ser
         return this.minecraftObj["minecraft:item"].description?.identifier ?? "$NAMESPACE:SHORTNAME";
     }
 
+    constructor(obj: ServerItemLoose, protected readonly subpath: string = "") {
+        super(obj);
+        this.subpath &&= this.subpath + "/";
+    }
+
     protected override validate(): ServerItemStrict {
         if (!this.minecraftObj["minecraft:item"]?.description?.identifier) {
             throw new Error("Item identifier is required");
@@ -139,7 +145,7 @@ export class MinecraftServerItem extends MinecraftWriteable<ServerItemLoose, Ser
 
     protected generate(): WriteableResponse<ModuleResponse> {
         const response = {
-            endpoint: `BP/items/${this.Shortname}.json`,
+            endpoint: `BP/items/${this.subpath}${this.Shortname}.json`,
             response: {
                 name: `${this.Shortname}`,
                 data: this.encode(),

--- a/src/api/classes/server_loot_table.ts
+++ b/src/api/classes/server_loot_table.ts
@@ -2,6 +2,9 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ServerLootTable } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Server Loot Tables.
+ */
 export class MinecraftServerLootTable extends MinecraftWriteable<ServerLootTable, ServerLootTable> {
     private readonly identifier: string;
 

--- a/src/api/classes/server_loot_table.ts
+++ b/src/api/classes/server_loot_table.ts
@@ -16,9 +16,10 @@ export class MinecraftServerLootTable extends MinecraftWriteable<ServerLootTable
         return this.identifier;
     }
 
-    constructor(name: string, obj: ServerLootTable) {
+    constructor(name: string, obj: ServerLootTable, protected readonly subpath: string = "") {
         super(obj);
         this.identifier = name;
+        this.subpath &&= this.subpath + "/";
     }
 
     protected override validate(): ServerLootTable {
@@ -27,7 +28,7 @@ export class MinecraftServerLootTable extends MinecraftWriteable<ServerLootTable
 
     protected generate(): WriteableResponse<ModuleResponse> {
         const response = {
-            endpoint: `BP/loot_tables/$PATH/${this.Identifier}.json`,
+            endpoint: `BP/loot_tables/$PATH/${this.subpath}${this.Identifier}.json`,
             response: {
                 name: `${this.Identifier}`,
                 data: this.encode(),

--- a/src/api/classes/server_recipe.ts
+++ b/src/api/classes/server_recipe.ts
@@ -9,6 +9,9 @@ const RecipeTypes = [
     "minecraft:recipe_brewing_mix",
 ];
 
+/**
+ * A class for creating and working with Server Recipes.
+ */
 export class MinecraftServerRecipe extends MinecraftWriteable<Partial<ServerRecipe>, ServerRecipe> {
     public get Recipe() : Partial<ServerRecipe> {
         return this.minecraftObj;

--- a/src/api/classes/server_recipe.ts
+++ b/src/api/classes/server_recipe.ts
@@ -25,6 +25,11 @@ export class MinecraftServerRecipe extends MinecraftWriteable<Partial<ServerReci
         ?? "$NAMESPACE:SHORTNAME";
     }
 
+    constructor(obj: Partial<ServerRecipe>, protected readonly subpath: string = "") {
+        super(obj);
+        this.subpath &&= this.subpath + "/";
+    }
+
     protected override validate(): ServerRecipe {
         if (RecipeTypes.every(value => !(value in this.minecraftObj))) {
             throw new Error(`Recipe must include one of ${RecipeTypes.join(", ")}`);
@@ -37,7 +42,7 @@ export class MinecraftServerRecipe extends MinecraftWriteable<Partial<ServerReci
 
     protected generate(): WriteableResponse<ModuleResponse> {
         const response = {
-            endpoint: `BP/recipes/${this.Shortname}.json`,
+            endpoint: `BP/recipes/${this.subpath}${this.Shortname}.json`,
             response: {
                 name: `${this.Shortname}`,
                 data: this.encode(),

--- a/src/api/classes/server_trade_table.ts
+++ b/src/api/classes/server_trade_table.ts
@@ -16,9 +16,10 @@ export class MinecraftServerTradeTable extends MinecraftWriteable<ServerTradeTab
         return this.identifier;
     }
 
-    constructor(name: string, obj: ServerTradeTable) {
+    constructor(name: string, obj: ServerTradeTable, protected readonly subpath: string = "") {
         super(obj);
         this.identifier = name;
+        this.subpath &&= this.subpath + "/";
     }
 
     protected override validate(): ServerTradeTable {
@@ -27,7 +28,7 @@ export class MinecraftServerTradeTable extends MinecraftWriteable<ServerTradeTab
 
     protected generate(): WriteableResponse<ModuleResponse> {
         const response = {
-            endpoint: `BP/trading/$PATH/${this.Identifier}.json`,
+            endpoint: `BP/trading/$PATH/${this.subpath}${this.Identifier}.json`,
             response: {
                 name: `${this.Identifier}`,
                 data: this.encode(),

--- a/src/api/classes/server_trade_table.ts
+++ b/src/api/classes/server_trade_table.ts
@@ -2,6 +2,9 @@ import type { WriteableResponse, ModuleResponse } from "../../core/core.ts";
 import type { ServerTradeTable } from "../types/index.ts";
 import { MinecraftWriteable } from "./minecraft_writeable.ts";
 
+/**
+ * A class for creating and working with Server Trade Tables.
+ */
 export class MinecraftServerTradeTable extends MinecraftWriteable<ServerTradeTable, ServerTradeTable> {
     private readonly identifier: string;
 

--- a/src/api/types/client_animation_controller.ts
+++ b/src/api/types/client_animation_controller.ts
@@ -1,11 +1,11 @@
-interface ClientAnimationController {
+export interface ClientAnimationController {
     initial_state?: string;
     states: {
         [key: string]: ClientAnimationControllerState
     }
 }
 
-interface ClientAnimationControllerState {
+export interface ClientAnimationControllerState {
     animations?: (string|{[key: string]: string})[];
     transitions?: {[key: string]: string}[];
     blend_transition?: number;

--- a/src/api/types/server_entity.ts
+++ b/src/api/types/server_entity.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file ban-types
 import type { ServerFilters, ServerFilterSubject } from "./filters.ts";
 import type { Float } from "./float.ts";
+import type { Trigger } from "./index.ts";
 import type { Molang } from "./molang.ts";
 import type { Components } from "./server_entity_components.ts";
 
@@ -57,7 +58,7 @@ export interface ServerEntityEvents {
     remove?: {
         component_groups: string[];
     };
-    trigger?: string;
+    trigger?: Trigger|string;
     randomize?: ServerEntityEvents[];
     sequence?: ServerEntityEvents[];
     set_property?: {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,3 +1,7 @@
+/**
+ * This module contains the command parser and handler for all of the CLI options.
+ * @module
+ */
 import { Logger, ModuleManager } from "../core/core.ts";
 import { Command } from "./command.ts";
 import "./commands/index.ts";
@@ -10,7 +14,7 @@ Command.parseCommands(Deno.args).then(result => {
     }
 }).catch(error => {
     Logger.error(error);
-}).finally(async () => {
-    await ModuleManager.shutdown();
+}).finally(() => {
+    ModuleManager.shutdown();
     Deno.exit(1);
 }); 

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -28,6 +28,9 @@ export interface CommandOptions<T extends CommandData> {
     action?: (args: T) => Promise<void>|void;
 }
 
+/**
+ * A custom command with parsing and execution support.
+ */
 export class Command<T extends CommandData> {
     private static registry: Command<CommandData>[] = [];
 

--- a/src/cli/commands/build.ts
+++ b/src/cli/commands/build.ts
@@ -2,7 +2,7 @@ import * as path from "@std/path";
 import { Command, type CommandData } from "../command.ts";
 import { Project } from "../../core/classes/project.ts";
 import { abortOnKeypress, Logger } from "../../core/utils/index.ts";
-import { Config } from "../../core/classes/config.ts";
+import { runCached } from "../utils/jsr.ts";
 
 interface BuildCommandData extends CommandData {
     options: {
@@ -63,19 +63,7 @@ export default new Command<BuildCommandData>({
     async action(_args) {
         // The build command delegates to the installed version of Netherite, passing the hidden --local flag.
         if (!_args.options.local) {
-            new Deno.Command("deno", {
-                args: [
-                    "run",
-                    "-A",
-                    `jsr:@coldiron/netherite@${Config.LocalNetheriteVersion}/cli`,
-                    ...Deno.args,
-                    "--local",
-                ],
-                stdin: "inherit",
-                stdout: "inherit",
-                stderr: "inherit",
-            }).outputSync();
-
+            await runCached([...Deno.args, "--local"]);
             return;
         }
 

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,5 +1,6 @@
 import { Command, type CommandData } from "../command.ts";
 import { Config, Exporter, type ExportType } from "../../core/classes/index.ts";
+import { runCached } from "../utils/jsr.ts";
 
 interface ExportCommandData extends CommandData {
     options: {
@@ -44,19 +45,7 @@ export default new Command<ExportCommandData>({
     async action(_args) {
         // The export command delegates to the installed version of Netherite, passing the hidden --local flag.
         if (!_args.options.local) {
-            new Deno.Command("deno", {
-                args: [
-                    "run",
-                    "-A",
-                    `jsr:@coldiron/netherite@${Config.LocalNetheriteVersion}/cli`,
-                    ...Deno.args,
-                    "--local",
-                ],
-                stdin: "inherit",
-                stdout: "inherit",
-                stderr: "inherit",
-            }).outputSync();
-
+            await runCached([...Deno.args, "--local"]);
             return;
         }
         

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,6 +1,6 @@
 import { Config } from "../core/classes/index.ts";
 
-const arg = Deno.args[0];
+const arg = Deno.args[0] ?? "latest";
 
 if (arg.match(/\d\.\d\.\d?.+/)) {
     new Deno.Command("deno", {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,3 +1,7 @@
+/**
+ * This module contains a lightweight install script for Netherite to run with minimal required permissions.
+ * @module
+ */
 import { Config } from "../core/classes/index.ts";
 
 const arg = Deno.args[0] ?? "latest";

--- a/src/cli/utils/jsr.ts
+++ b/src/cli/utils/jsr.ts
@@ -1,0 +1,43 @@
+import { Config, Logger } from "../../core/core.ts";
+import { commandWrap } from "../../core/utils/error.ts";
+
+export async function runCached(args: string[]): Promise<void> {
+    try {
+        await commandWrap(new Deno.Command("deno", {
+            args: [
+                "run",
+                "-A",
+                "--cached-only",
+                `jsr:@coldiron/netherite@${Config.LocalNetheriteVersion}/cli`,
+                ...args
+            ],
+            stdout: "inherit",
+        }));
+    } catch (_error) {
+        Logger.log(`Version ${Config.LocalNetheriteVersion} is not cached, attempting to download...`);
+        
+        try {
+            await commandWrap(new Deno.Command("deno", {
+                args: [
+                    "cache",
+                    `jsr:@coldiron/netherite@${Config.LocalNetheriteVersion}/cli`,
+                ],
+            stdout: "inherit",
+            }));
+
+            await commandWrap(new Deno.Command("deno", {
+                args: [
+                    "run",
+                    "-A",
+                    "--cached-only",
+                    `jsr:@coldiron/netherite@${Config.LocalNetheriteVersion}/cli`,
+                    ...args
+                ],
+                stdout: "inherit",
+            }));
+        } catch (_error) {
+            Logger.error(`Version ${Config.LocalNetheriteVersion} is not cached, and you appear to be offline.`);
+            Deno.exit(1);
+        }
+    }
+}

--- a/src/cli/utils/write.ts
+++ b/src/cli/utils/write.ts
@@ -1,4 +1,4 @@
-import type { MinecraftWriteable } from "../../api/api.ts";
+import type { MinecraftWriteable } from "../../api/classes/minecraft_writeable.ts";
 import { composites, writeBufferToSrc } from "../../core/core.ts";
 import encoded from "../../templates/encoded.ts";
 

--- a/src/core/classes/build/language.ts
+++ b/src/core/classes/build/language.ts
@@ -179,7 +179,6 @@ export class Language {
 
     /**
      * Adds a lang entry to the `src` lang files, *not* the dist.
-     * **This will remove any comments not formatted as categories (i.e. ## NAME =).**
      * @param category The category comment the entry should be added to.
      * @param key The lang key.
      * @param value The lang entry.
@@ -191,45 +190,18 @@ export class Language {
         for (const entry of Deno.readDirSync(path)) {
             if (!entry.name.endsWith(".lang")) continue;
             
+            let output = "";
             const fileContent = Deno.readTextFileSync(path + "/" + entry.name);
-            const categoryGroups = fileContent.split(/\n(?=#.+=+)/g);
-            const langMap = new Map<string, LangEntries>();
-            let contents = "";
+            const match = fileContent.match(new RegExp(`#+\\s*${category.toUpperCase()}.+`));
 
-            for (const categoryData of categoryGroups) {
-                const lines = categoryData
-                    .split("\n")
-                    .map(line => line.trim())
-                    .filter(line => line.length > 0);
-
-                if (lines.length === 0) continue;
-
-                const categoryName = (lines.shift() ?? "misc").replace(/#+ | =+/g, "").toLowerCase().trim();
-                const categoryMap: LangEntries = new Map();
-
-                for (const line of lines) {
-                    const [key, value] = line.split("=");
-                    categoryMap.set(key, value);
-                }
-
-                if (categoryName === category) categoryMap.set(key, value);
-
-                langMap.set(categoryName, categoryMap);
+            if (match) {
+                const index = match.index! + match[0].length;
+                output = fileContent.slice(0, index) + `\n${key}=${value}` + fileContent.slice(index);
+            } else {
+                output = fileContent + `\n${key}=${value}`;
             }
 
-            if (!langMap.has(category)) langMap.set(category, new Map([[key, value]]));
-
-            langMap.entries().forEach(([category, entry]) => {
-                contents += `## ${category.toUpperCase()} ${"=".repeat(117 - category.length)}\n`;
-
-                for (const [key, value] of entry) {
-                    contents += `${key}=${value}\n`;
-                }
-
-                contents += "\n";
-            });
-
-            Deno.writeTextFileSync(path + "/" + entry.name, contents.trim());
+            Deno.writeTextFileSync(path + "/" + entry.name, output.trim());
         }
     }
 

--- a/src/core/classes/package.ts
+++ b/src/core/classes/package.ts
@@ -3,6 +3,7 @@ import { Config } from "./config.ts";
 import { copyDirSync, JSONCParse, Logger } from "../utils/index.ts";
 import { publishToGitHub } from "../../cli/utils/github.ts";
 import { doesPathExist, emptyDirectorySync, sleep } from "../core.ts";
+import { commandWrap } from "../utils/error.ts";
 
 interface NetheritePackage {
     /**
@@ -571,14 +572,4 @@ export class Package {
             return packageValue;
         }
     }
-}
-
-async function commandWrap(command: Deno.Command): Promise<void> {
-    const result = await command.output();
-    if (result.success) return;
-
-    const err = new TextDecoder().decode(result.stderr);
-    const out = new TextDecoder().decode(result.stdout);
-
-    throw new Error(out + err);
 }

--- a/src/core/classes/project.ts
+++ b/src/core/classes/project.ts
@@ -92,7 +92,7 @@ export class Project {
         emptyDirectorySync(path.join(Deno.cwd(), "dist"));
         
         if (Config.Options.type !== "skin-pack") {
-            if (options?.ignoreSymlinks !== true) this.createSymlinks();
+            if (options?.ignoreSymlinks !== true) this.createSymlinks(options?.environment ?? "development");
             emptyDirectorySync(Config.Paths.bp.root);
             emptyDirectorySync(Config.Paths.rp.root);
         }
@@ -128,13 +128,14 @@ export class Project {
 
     private static createDirectories(): void {
         Deno.mkdirSync(path.join(Deno.cwd(), "src/modules"), {recursive: true});
-        this.createSymlinks();
+        this.createSymlinks("development");
     }
 
-    private static createSymlinks(): void {
+    private static createSymlinks(env: EnvironmentType): void {
         if (Config.Options.type === "skin-pack") return;
 
-        const projectNamespace = Config.PackName;
+        // Split prevents pack names from exceeding 10 characters which violates publishing rules
+        const projectNamespace = env === "production" ? Config.PackName.slice(-7) : Config.PackName;
 
         const mojangBP = path.join(Config.MojangDirectory, "development_behavior_packs", projectNamespace + "_bp");
         const mojangRP = path.join(Config.MojangDirectory, "development_resource_packs", projectNamespace + "_rp");

--- a/src/core/utils/error.ts
+++ b/src/core/utils/error.ts
@@ -16,3 +16,13 @@ export async function attemptRepeater(func: () => unknown, prefix: string = "Act
 
     Logger.error(`${prefix} failed due to: ${lastError}`);
 }
+
+export async function commandWrap(command: Deno.Command): Promise<void> {
+    const result = await command.output();
+    if (result.success) return;
+
+    const err = new TextDecoder().decode(result.stderr);
+    const out = new TextDecoder().decode(result.stdout);
+
+    throw new Error(out + err);
+}


### PR DESCRIPTION
## Fixes
- Fixed issue where `MinecraftServerEntity`'s event.trigger only accepted a string rather than a full event trigger.
- Improved exported API commenting.
- Fixed error that could occur when running the install script.
- Fixed CI/CD error that caused the publish action to fail.
- Fixed issue where module docs were not provided.
- Fixed issue where `new` subcommands could fail due to how the lang file was parsed.
- Fixed issue where 1.0.1 was missing a changelog entry.
- Fixed issue where only some `MinecraftWriteable` API members supported export subpaths.
- Fixed issue where the API exported some under-the-hood classes that should not be called during usage.
- Fixed issue where `netherite build` and `netherite export` would fail when offline, or when JSR was unavailable (such as the 24 supply-chain protection window) which would prevent hotfixes from being usable.
- Fixed issue where exported behavior/resource pack names could exceed the ten character limit enforced by Auger.
